### PR TITLE
Rollup: externalize Buffer for node to avoid module import

### DIFF
--- a/scripts/config.js
+++ b/scripts/config.js
@@ -30,7 +30,9 @@ const external = [
     'google-protobuf',
     'grpc-web-client',
     'bs58check',
-    'bs58'
+    'bs58',
+    'buffer',
+    'jsbi'
 ];
 
 // Treating these as external as they are runtime requirements for node only

--- a/src/transactions/utils.js
+++ b/src/transactions/utils.js
@@ -1,4 +1,5 @@
 import bs58 from 'bs58';
+import { Buffer } from 'buffer';
 
 export function encodeTxHash(bytes) {
     return bs58.encode(Buffer.from(bytes));


### PR DESCRIPTION
The node.js build is currently broken because `Buffer` is rewritten to use an external module that doesn't pass the `Buffer.isBuffer()` check. 